### PR TITLE
Added ability to pay bridge network fees in network's base token

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -37,12 +37,12 @@ contract Bridge is IBridgeNonFungible, IBridgeMixedFungible, Controllable, ERC11
 	 * @dev Returns the chainId of the network this contract is deployed on
 	 */
 	/*function chainId() public view returns (uint256) {
-		uint256 id;
-		assembly {
-			id := chainid()
-		}
-		return id;
-	}*/
+	  uint256 id;
+	  assembly {
+id := chainid()
+}
+return id;
+}*/
 
 	/**
 	 * @dev Transfers an ERC20 token to a different chain
@@ -53,7 +53,10 @@ contract Bridge is IBridgeNonFungible, IBridgeMixedFungible, Controllable, ERC11
 		uint256 amount,
 		uint256 networkId,
 		bytes calldata
-	) external virtual override {
+	) external virtual override payable {
+		// This function is only payable so it can be overriden by TollBridge. We don't want to actually except any ETH 
+		require(msg.value == 0, "Bridge: Function not payable");
+
 		_transferFungible(token, amount, networkId);
 	}
 
@@ -81,13 +84,16 @@ contract Bridge is IBridgeNonFungible, IBridgeMixedFungible, Controllable, ERC11
 		uint256 _tokenId,
 		uint256 _networkId,
 		bytes calldata
-	) external virtual override {
+	) external virtual override payable {
+		// This function is only payable so it can be overriden by TollBridge. We don't want to actually except any ETH 
+		require(msg.value == 0, "Bridge: Function not payable");
+
 		_transferNonFungible(_token, _tokenId, _networkId);
 	}
 
 	/**
-	 * @dev Used by bridge network to transfer the item directly to user without need for manual claiming
-	 */
+	* @dev Used by bridge network to transfer the item directly to user without need for manual claiming
+	*/
 	function bridgeClaimNonFungible(
 		address _token,
 		address _to,
@@ -125,7 +131,10 @@ contract Bridge is IBridgeNonFungible, IBridgeMixedFungible, Controllable, ERC11
 		uint256 _amount,
 		uint256 _networkId,
 		bytes calldata
-	) external virtual override {
+	) external virtual override payable {
+		// This function is only payable so it can be overriden by TollBridge. We don't want to actually except any ETH 
+		require(msg.value == 0, "Bridge: Function not payable");
+
 		_transferMixedFungible(_token, _tokenId, _amount, _networkId);
 	}
 

--- a/contracts/IBridge.sol
+++ b/contracts/IBridge.sol
@@ -9,7 +9,7 @@ interface IBridge {
 	 * @dev Transfers an ERC20 token to a different chain
 	 * This function simply moves the caller's tokens to this contract, and emits a `TokenTransferFungible` event
 	 */
-	function transferFungible(address token, uint256 amount, uint256 networkId, bytes calldata data) external;
+	function transferFungible(address token, uint256 amount, uint256 networkId, bytes calldata data) external payable;
 
 	/**
 	 * @dev Used by the bridge relay to 'transfer' a user's item to the chain

--- a/contracts/IBridgeMixedFungible.sol
+++ b/contracts/IBridgeMixedFungible.sol
@@ -12,7 +12,7 @@ interface IBridgeMixedFungible is IBridge, IERC1155ReceiverUpgradeable {
 	 * @dev Transfers an ERC1155 token to a different chain
 	 * This function simply moves the caller's tokens to this contract, and emits a `TokenTransferMixedFungible` event
 	 */
-	function transferMixedFungible(address token, uint256 tokenId, uint256 amount, uint256 networkId, bytes calldata data) external;
+	function transferMixedFungible(address token, uint256 tokenId, uint256 amount, uint256 networkId, bytes calldata data) external payable;
 
 	/**
 	 * @dev Used by the bridge relay to 'transfer' a user's item to the chain

--- a/contracts/IBridgeNonFungible.sol
+++ b/contracts/IBridgeNonFungible.sol
@@ -11,7 +11,7 @@ interface IBridgeNonFungible is IBridge {
 	 * @dev Transfers an ERC721 token to a different chain
 	 * This function simply moves the caller's tokens to this contract, and emits a `TokenTransferFungible` event
 	 */
-	function transferNonFungible(address token, uint256 tokenId, uint256 networkId, bytes calldata data) external;
+	function transferNonFungible(address token, uint256 tokenId, uint256 networkId, bytes calldata data) external payable;
 
 	/**
 	 * @dev Used by the bridge relay to 'transfer' a user's item to the chain

--- a/contracts/TollBridge.sol
+++ b/contracts/TollBridge.sol
@@ -2,11 +2,13 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import "./Bridge.sol";
 
 contract TollBridge is Bridge {
 	using ECDSAUpgradeable for bytes32;
 	using ECDSAUpgradeable for bytes;
+	using AddressUpgradeable for address payable;
 
 	// Fees that have been paid and can be withdrawn from this contract
 	mapping (address => uint256) public pendingFees;
@@ -77,7 +79,7 @@ contract TollBridge is Bridge {
 	   uint256 _amount,
 		uint256 _networkId,
 		bytes calldata _feeData
-	) external virtual override {
+	) external virtual override payable {
       verifyFee(_networkId, _token, _feeData);
 	
 		_transferFungible(_token, _amount, _networkId);
@@ -94,7 +96,7 @@ contract TollBridge is Bridge {
 		uint256 _tokenId,
 		uint256 _networkId,
 		bytes calldata _feeData
-	) external virtual override {
+	) external virtual override payable {
 		// require(networkId != chainId(), "Same chainId");
       verifyFee(_networkId, _token, _feeData);
 		
@@ -113,7 +115,7 @@ contract TollBridge is Bridge {
 		uint256 _amount,
 		uint256 _networkId,
 		bytes calldata _feeData
-	) external virtual override {
+	) external virtual override payable {
 		// require(networkId != chainId(), "Same chainId");
       verifyFee(_networkId, _token, _feeData);
 		
@@ -125,7 +127,12 @@ contract TollBridge is Bridge {
 	function withdrawalFees(address _token, uint256 _amount) external virtual onlyController {
 		require(pendingFees[_token] >= _amount, "Insufficient funds");
 		pendingFees[_token] -= _amount;
-		IERC20Upgradeable(_token).transfer(_msgSender(), _amount);
+
+		if(_token == address(0)) {
+			payable(_msgSender()).sendValue(_amount);
+		} else {
+			IERC20Upgradeable(_token).transfer(_msgSender(), _amount);
+		}
 	}
 
 	/**
@@ -137,9 +144,17 @@ contract TollBridge is Bridge {
 
 		(token, fee,,, ) = abi.decode(_feeData, (address, uint256, uint256, bytes32, bytes));
 
-		if(fee > 0) {
+		// token == address(0) is used to indicate fee will be payed in base network currency (ie. ETH on Ethereum, etc.)
+		if(token == address(0) && fee > 0) {
+			require(msg.value == fee, "TollBridge: Incorrect fee paid");
+		} else if(fee > 0) {
+			// Only make payable if the fee is in base network currency
+			require(msg.value == 0, "TollBridge: Function not payable");
 			pendingFees[token] += fee;
 			IERC20Upgradeable(token).transferFrom(_msgSender(), address(this), fee);
+		} else /* fee == 0 */ {
+			// Only make payable if the fee is in base network currency
+			require(msg.value == 0, "TollBridge: Function not payable");
 		}
 	}
 }

--- a/test/toll_bridge.ts
+++ b/test/toll_bridge.ts
@@ -17,8 +17,6 @@ describe("Toll Bridge", function () {
   const feeAmount = 1000;
   let tollToken: Contract;
 
-
-
   beforeEach(async function () {
     // Setup the token to use for tolls
 
@@ -112,7 +110,7 @@ describe("Toll Bridge", function () {
       });
     });
 
-    it("Transfer a fungilbe token to another network with fee", async function () {
+    it("Transfer a fungilbe token to another network with fee paid in ERC-20", async function () {
       const [owner, addr1] = await ethers.getSigners();
 
       const mockERC20 = await deployMockContract(owner, IERC20.abi);
@@ -155,6 +153,53 @@ describe("Toll Bridge", function () {
       }
 
       expect(pass).to.equal(true);
+    });
+
+    it("Transfer a fungilbe token to another network with fee paid in ETH", async function () {
+      const [owner, addr1] = await ethers.getSigners();
+
+      const mockERC20 = await deployMockContract(owner, IERC20.abi);
+
+      await mockERC20.mock.transferFrom.returns(true);
+      await mockERC20.mock.transfer.returns(true);
+
+      const Bridge = await ethers.getContractFactory("TollBridge");
+      const bridge = await upgrades.deployProxy(Bridge, [
+        owner.address,
+        addr1.address,
+      ]);
+      await bridge.deployed();
+
+      // Generate fee verification
+      const feeData = await generateFeeData(
+        owner.address,
+        2,
+        zeroAddress,
+        feeAmount,
+        noExpireBlock,
+        mockERC20.address,
+        addr1
+      );
+
+      const transferTx = await bridge.transferFungible(
+        mockERC20.address,
+        100,
+        2,
+        feeData,
+        { value: feeAmount }
+      );
+
+      const tx = await transferTx.wait();
+
+      expect(tx.events?.length).to.equal(1);
+
+      // @ts-ignore
+      await tx.events?.forEach((e) => {
+        expect(e.args?.from).to.equal(owner.address);
+        expect(e.args?.token).to.equal(mockERC20.address);
+        expect(parseInt(e.args?.amount)).to.equal(100);
+        expect(parseInt(e.args?.networkId)).to.equal(2);
+      });
     });
   });
 
@@ -240,7 +285,40 @@ describe("Toll Bridge", function () {
       });
     });
 
-    it("Transfer a non-fungilbe token to another network with fee", async function () {
+    it("Claim a non-fungible token that was transfered and the NFT does not exist", async function () {
+      const [owner, addr1] = await ethers.getSigners();
+
+      const mockERC721 = await deployMockContract(owner, IERC721.abi);
+
+      await mockERC721.mock.transferFrom.returns();
+      await mockERC721.mock.ownerOf.withArgs(1).reverts();
+
+      const Bridge = await ethers.getContractFactory("TollBridge");
+      const bridge = await upgrades.deployProxy(Bridge, [
+        owner.address,
+        addr1.address,
+      ]);
+      await bridge.deployed();
+
+      await mockERC721.mock.ownerOf.withArgs(1).returns(bridge.address);
+
+      // Claim token
+      const claimTx = await bridge.bridgeClaimNonFungible(
+        mockERC721.address,
+        addr1.address,
+        1
+      );
+      const tx = await claimTx.wait();
+
+      // @ts-ignore
+      await tx.events?.forEach((e) => {
+        expect(e.args?.from).to.equal(addr1.address);
+        expect(e.args?.token).to.equal(mockERC721.address);
+        expect(parseInt(e.args?.tokenId)).to.equal(1);
+      });
+    });
+
+    it("Transfer a non-fungilbe token to another network with fee in ERC-20", async function () {
       const [owner, addr1] = await ethers.getSigners();
 
       const mockERC721 = await deployMockContract(owner, IERC721.abi);
@@ -285,13 +363,12 @@ describe("Toll Bridge", function () {
       expect(pass).to.equal(true);
     });
 
-    it("Claim a non-fungible token that was transfered and the NFT exist and is owned by bridge contract", async function () {
+    it("Transfer a non-fungilbe token to another network with fee in ETH", async function () {
       const [owner, addr1] = await ethers.getSigners();
 
       const mockERC721 = await deployMockContract(owner, IERC721.abi);
 
       await mockERC721.mock.transferFrom.returns();
-      await mockERC721.mock.ownerOf.withArgs(1).reverts();
 
       const Bridge = await ethers.getContractFactory("TollBridge");
       const bridge = await upgrades.deployProxy(Bridge, [
@@ -300,21 +377,35 @@ describe("Toll Bridge", function () {
       ]);
       await bridge.deployed();
 
-      await mockERC721.mock.ownerOf.withArgs(1).returns(bridge.address);
-
-      // Claim token
-      const claimTx = await bridge.bridgeClaimNonFungible(
+      // Generate fee verification
+      const feeData = await generateFeeData(
+        owner.address,
+        2,
+        zeroAddress,
+        feeAmount,
+        noExpireBlock,
         mockERC721.address,
-        addr1.address,
-        1
+        addr1
       );
-      const tx = await claimTx.wait();
+
+      const transferTx = await bridge.transferNonFungible(
+        mockERC721.address,
+        1,
+        2,
+        feeData,
+        { value: feeAmount }
+      );
+
+      const tx = await transferTx.wait();
+
+      expect(tx.events?.length).to.equal(1);
 
       // @ts-ignore
       await tx.events?.forEach((e) => {
-        expect(e.args?.from).to.equal(addr1.address);
+        expect(e.args?.from).to.equal(owner.address);
         expect(e.args?.token).to.equal(mockERC721.address);
         expect(parseInt(e.args?.tokenId)).to.equal(1);
+        expect(parseInt(e.args?.networkId)).to.equal(2);
       });
     });
   });
@@ -370,7 +461,7 @@ describe("Toll Bridge", function () {
       });
     });
 
-    it("Transfer a mixed fungilbe token to another network with fee", async function () {
+    it("Transfer a mixed fungilbe token to another network with fee in ERC-20", async function () {
       const [owner, addr1] = await ethers.getSigners();
 
       const mockERC1155 = await deployMockContract(owner, IERC1155.abi);
@@ -420,6 +511,53 @@ describe("Toll Bridge", function () {
       }
 
       expect(pass).to.equal(true);
+    });
+
+    it("Transfer a mixed fungilbe token to another network with fee in ETH", async function () {
+      const [owner, addr1] = await ethers.getSigners();
+
+      const mockERC1155 = await deployMockContract(owner, IERC1155.abi);
+
+      await mockERC1155.mock.safeTransferFrom.returns();
+
+      const Bridge = await ethers.getContractFactory("TollBridge");
+      const bridge = await upgrades.deployProxy(Bridge, [
+        owner.address,
+        addr1.address,
+      ]);
+      await bridge.deployed();
+
+      // Generate fee verification
+      const feeData = await generateFeeData(
+        owner.address,
+        2,
+        zeroAddress,
+        feeAmount,
+        noExpireBlock,
+        mockERC1155.address,
+        addr1
+      );
+
+      const transferTx = await bridge.transferMixedFungible(
+        mockERC1155.address,
+        1,
+        100,
+        2,
+        feeData,
+        { value: feeAmount }
+      );
+      const tx = await transferTx.wait();
+
+      expect(tx.events?.length).to.equal(1);
+
+      // @ts-ignore
+      await tx.events?.forEach((e) => {
+        expect(e.args?.from).to.equal(owner.address);
+        expect(e.args?.token).to.equal(mockERC1155.address);
+        expect(parseInt(e.args?.tokenId)).to.equal(1);
+        expect(parseInt(e.args?.amount)).to.equal(100);
+        expect(parseInt(e.args?.networkId)).to.equal(2);
+      });
     });
 
     it("Claim a mixed fungible token that was transfered", async function () {


### PR DESCRIPTION
If the fee token address is set to the zero address the base currency of the network will be used as the fee currency (ie. ETH on Ethereum, MATIC on Polygon, etc).

To facilitate reception of this fee, the transfer contracts are payable, but will revert if they don't receive the exact amount of `base token` required to pay the fee. This means if the fee token is not the zero address, the transfer functions are essentially not payable.