### PR TITLE
Changed fee verification to now include tokenId and/or tokenAmount

### DIFF
--- a/contracts/TollBridge.sol
+++ b/contracts/TollBridge.sol
@@ -81,7 +81,7 @@ contract TollBridge is Bridge {
 		uint256 _networkId,
 		bytes calldata _feeData
 	) external virtual override payable {
-      verifyFee(_networkId, abi.encode(_token), _feeData);
+      verifyFee(_networkId, abi.encode(_token, _amount), _feeData);
 	
 		_transferFungible(_token, _amount, _networkId);
 
@@ -99,7 +99,7 @@ contract TollBridge is Bridge {
 		bytes calldata _feeData
 	) external virtual override payable {
 		// require(networkId != chainId(), "Same chainId");
-      verifyFee(_networkId, abi.encode(_token), _feeData);
+      verifyFee(_networkId, abi.encode(_token, _tokenId), _feeData);
 		
 		_transferNonFungible(_token, _tokenId, _networkId);
 
@@ -118,7 +118,7 @@ contract TollBridge is Bridge {
 		bytes calldata _feeData
 	) external virtual override payable {
 		// require(networkId != chainId(), "Same chainId");
-      verifyFee(_networkId, abi.encode(_token), _feeData);
+      verifyFee(_networkId, abi.encode(_token, _tokenId, _amount), _feeData);
 		
 		_transferMixedFungible(_token, _tokenId, _amount, _networkId);
 

--- a/test/fee_verify.ts
+++ b/test/fee_verify.ts
@@ -53,7 +53,7 @@ describe("Fee Verification Signature", function () {
       feeToken,
       feeAmount,
       maxBlock,
-      mockERC20.address,
+      { tokenAddr: mockERC20.address, tokenId: null, tokenAmount: null },
       testMessage,
       true,
       addr1
@@ -115,7 +115,7 @@ describe("Fee Verification Signature", function () {
       feeToken,
       feeAmount,
       maxBlock,
-      mockERC20.address,
+      { tokenAddr: mockERC20.address, tokenId: null, tokenAmount: null },
       testMessage,
       true,
       addr1
@@ -183,7 +183,7 @@ describe("Fee Verification Signature", function () {
       feeToken,
       feeAmount,
       maxBlock,
-      zeroAddress,
+      { tokenAddr: zeroAddress, tokenId: null, tokenAmount: null },
       testMessage,
       true,
       addr1

--- a/test/helpers/messageSigning.ts
+++ b/test/helpers/messageSigning.ts
@@ -10,7 +10,7 @@ export async function generateHashedMessage(
   feeToken, // @ts-ignore
   feeAmount, // @ts-ignore
   maxBlock, // @ts-ignore
-  tokenAddr, // @ts-ignore
+  { tokenAddr, tokenId, tokenAmount }, // @ts-ignore
   messageData,
   requestReceipt: boolean, // @ts-ignore
   signer
@@ -23,7 +23,19 @@ export async function generateHashedMessage(
 
   if (!messageData || messageData === "0x") {
     // console.log("Packing in token mode");
-    packedMessage = abi.encode(["address"], [tokenAddr]);
+    if (tokenId && tokenAmount) {
+      packedMessage = abi.encode(
+        ["address", "uint256", "uint256"],
+        [tokenAddr, tokenId, tokenAmount]
+      );
+    } else if (tokenId) {
+      packedMessage = abi.encode(["address", "uint256"], [tokenAddr, tokenId]);
+    } else if (tokenAmount) {
+      packedMessage = abi.encode(
+        ["address", "uint256"],
+        [tokenAddr, tokenAmount]
+      );
+    }
   } else if (tokenAddr !== zeroAddress && tokenAddr) {
     // console.log("Packing in message mode");
     packedMessage = abi.encode(
@@ -90,7 +102,7 @@ export async function generateFeeData(
   feeToken, // @ts-ignore
   feeAmount, // @ts-ignore
   maxBlock, // @ts-ignore
-  tokenAddr, // @ts-ignore
+  tokenData, // @ts-ignore
   messageData,
   requestReceipt: boolean, // @ts-ignore
   signer, // @ts-ignore
@@ -110,7 +122,7 @@ export async function generateFeeData(
     feeToken,
     feeAmount,
     maxBlock,
-    tokenAddr,
+    tokenData,
     messageData,
     requestReceipt,
     signer

--- a/test/toll_bridge.ts
+++ b/test/toll_bridge.ts
@@ -54,7 +54,7 @@ describe("Toll Bridge", function () {
         fakeFeeTokenAddr,
         0,
         noExpireBlock,
-        mockERC20.address,
+        { tokenAddr: mockERC20.address, tokenAmount: 100 },
         "0x",
         false,
         addr1,
@@ -141,7 +141,7 @@ describe("Toll Bridge", function () {
         tollToken.address,
         feeAmount,
         noExpireBlock,
-        mockERC20.address,
+        { tokenAddr: mockERC20.address, tokenAmount: 100 },
         "0x",
         false,
         addr1,
@@ -184,7 +184,7 @@ describe("Toll Bridge", function () {
         zeroAddress,
         feeAmount,
         noExpireBlock,
-        mockERC20.address,
+        { tokenAddr: mockERC20.address, tokenAmount: 100 },
         null,
         false,
         addr1,
@@ -237,7 +237,7 @@ describe("Toll Bridge", function () {
         tollToken.address,
         0,
         noExpireBlock,
-        mockERC721.address,
+        { tokenAddr: mockERC721.address, tokenId: 1 },
         "0x",
         false,
         addr1,
@@ -352,7 +352,7 @@ describe("Toll Bridge", function () {
         tollToken.address,
         feeAmount,
         noExpireBlock,
-        mockERC721.address,
+        { tokenAddr: mockERC721.address, tokenId: 1 },
         "0x",
         false,
         addr1,
@@ -400,7 +400,7 @@ describe("Toll Bridge", function () {
         zeroAddress,
         feeAmount,
         noExpireBlock,
-        mockERC721.address,
+        { tokenAddr: mockERC721.address, tokenId: 1 },
         null,
         false,
         addr1,
@@ -453,7 +453,7 @@ describe("Toll Bridge", function () {
         tollToken.address,
         0,
         noExpireBlock,
-        mockERC1155.address,
+        { tokenAddr: mockERC1155.address, tokenId: 1, tokenAmount: 100 },
         "0x",
         false,
         addr1,
@@ -511,7 +511,7 @@ describe("Toll Bridge", function () {
         tollToken.address,
         feeAmount,
         noExpireBlock,
-        mockERC1155.address,
+        { tokenAddr: mockERC1155.address, tokenId: 1, tokenAmount: 100 },
         "0x",
         false,
         addr1,
@@ -559,7 +559,7 @@ describe("Toll Bridge", function () {
         zeroAddress,
         feeAmount,
         noExpireBlock,
-        mockERC1155.address,
+        { tokenAddr: mockERC1155.address, tokenId: 1, tokenAmount: 100 },
         null,
         false,
         addr1,
@@ -640,7 +640,7 @@ describe("Toll Bridge", function () {
       encodedMessage = abi.encode(decodedMessage.types, decodedMessage.data);
     });
 
-    it("Send an arbitrary message to another network", async function () {
+    it("Send an arbitrary message to another network with ERC-20 fee", async function () {
       const [owner, addr1] = await ethers.getSigners();
 
       const Bridge = await ethers.getContractFactory("TollBridge");
@@ -657,7 +657,7 @@ describe("Toll Bridge", function () {
         tollToken.address,
         feeAmount,
         noExpireBlock,
-        addr1.address,
+        { tokenAddr: addr1.address },
         // @ts-ignore
         encodedMessage,
         false,


### PR DESCRIPTION
This doesn't really matter in most cases, but there may be some niche cases where a certain tokenId or amount of tokens will cost a different amount of gas to transfer. This is also an obvious attack vector. Although the only benefit would be reduced fees.

I suppose a contract could be made to exploit this. For example, an "ERC-20" token with a transfer function that, when only used for one item just does nothing, but when used for any more deploys hundreds of smart contracts, and/or other very expensive operations. I don't think this attack is actually possible, given the way the bridge network works, and the fact projects (at least as of now) need to be approved to be part of the Xenum network.

Best not to risk it, regardless.